### PR TITLE
Use window-supported methods for accessing the query string params

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -13,11 +13,19 @@ const emailTitle = 'Help us change the world.'
 
 class Home extends React.Component {
   static async getInitialProps ({ query }) {
+    // this only gets called when SSR is on
+    // but not when the site is static exported
     return { query }
   }
 
   componentDidMount () {
-    const { email, auth } = this.props.query
+    let qs = this.props.query
+    let { email, auth } = qs
+    if (typeof window !== 'undefined') {
+      qs = new URLSearchParams(window.location.search)
+      email = qs.get('email')
+      auth = qs.get('auth')
+    }
     console.log('props', this.props)
     console.log(email, auth)
     if (email && auth) {


### PR DESCRIPTION
2nd part of auth flow wasn't working in staging + prod because the logic was built around using SSR which we don't use in staging and prod. Updated the logic to use the built-in methods on the window when available.

As a follow up, we might want to update `npm run dev` to live reload `npm run now-build && serve dist`, so that no more SSR-only logic gets introduced by accident.