### PR TITLE
Fixed stripe input width.

### DIFF
--- a/components/donateform.js
+++ b/components/donateform.js
@@ -111,7 +111,7 @@ class DonateForm extends Component {
         <input className='bn pa2 w5 ma1 br2' placeholder='Last name' value={this.state.lastName} onChange={this.updateLastName} />
         <input className='bn pa2 w5 ma1 br2' placeholder='Email' value={this.state.email} onChange={this.updateEmail} />
         <input className='bn pa2 w5 ma1 br2' placeholder='$ Amount' value={this.state.amount} onChange={this.updateAmount} />
-        <div className='bg-white bn pa2 w-100 mt1 mb1 br2'>
+        <div className='bg-white bn pa2 ma1 br2'>
           <CardElement />
         </div>
         { loading && <h2 className='tc tf-lato'>Loading...</h2>}


### PR DESCRIPTION
I believe this worked. Here's Chrome, Edge, and Firefox:

![chrome](https://user-images.githubusercontent.com/7775971/57182708-06fd8980-6e57-11e9-9c04-c79ebf8dbc33.JPG)

![edge](https://user-images.githubusercontent.com/7775971/57182709-09f87a00-6e57-11e9-8cf2-e4367585bb5f.JPG)

![fox](https://user-images.githubusercontent.com/7775971/57182710-0bc23d80-6e57-11e9-9908-10ce3486031f.JPG)

The code before:

![before](https://user-images.githubusercontent.com/7775971/57182719-344a3780-6e57-11e9-938e-4742be1f2de7.JPG)

And after:

![after](https://user-images.githubusercontent.com/7775971/57182722-390eeb80-6e57-11e9-96f4-83abfc2464e6.JPG)

I'm not super thrilled about this, because I don't know what's happening inside the `<CardElement />` to get the width right, as all I've done is remove the w-100 class and add the margin all the way around in its parent div, and now it (magically?) works. Any concerns about that?