### PR TITLE
Vertical center for labels in two item switcher.

### DIFF
--- a/components/twoItemSwitcher.js
+++ b/components/twoItemSwitcher.js
@@ -3,10 +3,10 @@ import '../static/styles/main.scss'
 
 const TwoItemSwitcher = (props) => (
   <div className='flex flex-row tf-lato justify-between ma1'>
-    <div className={`w-100 h2 tc mt1 br--left br2 ${props.color} ${props.selectedToggle === 1 ? 'tf-dark-gray bg-white' : 'bg-tf-yellow white'}`} onClick={props.switchOneClicked}>
+    <div className={`w-100 h2 tc mt1 br--left br2 flex flex-column justify-center ${props.color} ${props.selectedToggle === 1 ? 'tf-dark-gray bg-white' : 'bg-tf-yellow white'}`} onClick={props.switchOneClicked}>
       <label className='ttu v-mid'>{props.switchOneText}</label>
     </div>
-    <div className={`w-100 h2 tc mt1 br--right br2 ${props.color} ${props.selectedToggle === 2 ? 'tf-dark-gray bg-white' : 'bg-tf-yellow white'}`} onClick={props.switchTwoClicked}>
+    <div className={`w-100 h2 tc mt1 br--right br2 flex flex-column justify-center ${props.color} ${props.selectedToggle === 2 ? 'tf-dark-gray bg-white' : 'bg-tf-yellow white'}`} onClick={props.switchTwoClicked}>
       <label className='ttu v-mid'>{props.switchTwoText}</label>
     </div>
   </div>


### PR DESCRIPTION
For issue #81, added Tachyon Flexbox classes. Looks like it worked:

![center](https://user-images.githubusercontent.com/7775971/57201007-ac902600-6f47-11e9-94d4-d847366acacc.JPG)
