### PR TITLE
Use form and button elements for donation form

### DIFF
--- a/components/donateform.js
+++ b/components/donateform.js
@@ -47,6 +47,7 @@ class DonateForm extends Component {
   }
 
   donate = async (ev) => {
+    ev.preventDefault()
     this.setLocalState({ loading: true })
     let token
     try {
@@ -94,7 +95,7 @@ class DonateForm extends Component {
     if (redirectSuccess) return (<div />)
 
     return (
-      <div className='flex flex-column'>
+      <form className='flex flex-column' onSubmit={this.donate}>
         <div className='error tf-lato tc'>
           <p className='red'>{this.state.error}</p>
         </div>
@@ -114,10 +115,8 @@ class DonateForm extends Component {
           <CardElement />
         </div>
         { loading && <h2 className='tc tf-lato'>Loading...</h2>}
-        <div className='white bg-tf-teal tf-lato b tc pa2 ma3 br-pill' onClick={this.donate}>
-          <label className='ttu'>Donate</label>
-        </div>
-      </div>
+        <button type='submit' className='white bg-tf-teal tf-lato b tc pa2 ma3 br-pill ttu'>Donate</button>
+      </form>
     )
   }
 }


### PR DESCRIPTION
Currently, the donation form was using `div` elements for the form itself as well as the "donate" button. This is not semantic HTML, and it also removes a lot of built in accessibility and functionality the browser takes care of for us.

I've changed it to use a `form` element and the `onSubmit` event (vs the `click` event it was using which not only gives us semantic markup, but by using  a form, anyone navigating with their keyboard can use the `enter` key to submit it, which is expected behavior (and will trigger the `donate` function just as clicking the button does).

I have also used a `button` element for the "donate" button, making things semantic as well as fully keyboard accessible. 