### PR TITLE
Break team section into components

### DIFF
--- a/components/team.js
+++ b/components/team.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import TeamMember from './teamMember';
+
+const teamMembers = [
+  {
+    name: 'Joel Wasserman',
+    src: 'joel.jpg',
+    bio: `A software engineer at Google, Joel formerly worked
+          at two education startups and is passionate about public education and technology.`
+  },
+  {
+    name: 'Christine Woeller',
+    src: 'christine.jpeg',
+    bio: `With a degree in secondary education, Christine seeks to improve public schools
+          and ensure teachers have the best resources available.`
+  }, 
+  {
+    name: 'Peter Squicciarini',
+    src: 'pete.jpeg',
+    bio: ` A software developer at Amazon and loving father of two, Peter strives to
+          help all children and teachers succeed in an educational environment.`
+  }
+]
+
+const Team = (props) =>
+  (
+    <section className='h-section mb5 mb0-ns pb5-ns'>
+      <div className='flex flex-column z-100'>
+        <div className='bg-tf-gray o-10 dn db-ns dn-m h-section w-100 absolute' />
+        <h2 className='ts-title tf-oswald pt5-l mv0 center'>
+          Meet the Team
+        </h2>
+        <ul className='list flex flex-row flex-wrap justify-center w-auto mt3 mb0 pv0 ph0 center'>
+          {teamMembers.map(member => 
+            <TeamMember name={member.name} src={member.src} bio={member.bio} />)
+          }
+        </ul>
+      </div>
+    </section>
+  )
+
+export default Team

--- a/components/team.js
+++ b/components/team.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import TeamMember from './teamMember';
+import TeamMember from './teamMember'
 
 const teamMembers = [
   {
@@ -13,7 +13,7 @@ const teamMembers = [
     src: 'christine.jpeg',
     bio: `With a degree in secondary education, Christine seeks to improve public schools
           and ensure teachers have the best resources available.`
-  }, 
+  },
   {
     name: 'Peter Squicciarini',
     src: 'pete.jpeg',
@@ -31,7 +31,7 @@ const Team = (props) =>
           Meet the Team
         </h2>
         <ul className='list flex flex-row flex-wrap justify-center w-auto mt3 mb0 pv0 ph0 center'>
-          {teamMembers.map(member => 
+          {teamMembers.map(member =>
             <TeamMember name={member.name} src={member.src} bio={member.bio} />)
           }
         </ul>

--- a/components/teamMember.js
+++ b/components/teamMember.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const TeamMember = (props) => 
+const TeamMember = (props) =>
   (
     <li className='bg-white z-1 ma4-l w-50-m w-25-l w-80'>
       <div className='w-100 bg-transparent pa4-l'>

--- a/components/teamMember.js
+++ b/components/teamMember.js
@@ -1,0 +1,22 @@
+import React from 'react'
+
+const TeamMember = (props) => 
+  (
+    <li className='bg-white z-1 ma4-l w-50-m w-25-l w-80'>
+      <div className='w-100 bg-transparent pa4-l'>
+        <div className='pa2-l tc'>
+          <div className='center br-100 ba b--black-05 ma3 h4 w4 bg-white overflow-hidden'>
+            <img src={'/static/images/people/' + props.src} alt='' />
+          </div>
+          <h3 className='tf-oswald ts-subtext pv2 tc mv0'>
+            {props.name}
+          </h3>
+          <p className='tf-lato-lite ts-subtext pt2 tc mv0'>
+            {props.bio}
+          </p>
+        </div>
+      </div>
+    </li>
+  )
+
+export default TeamMember

--- a/pages/index.js
+++ b/pages/index.js
@@ -87,7 +87,7 @@ class IndexPage extends Component {
       <div className='bg-white index tf-dark-gray'>
         <Head />
         <section className='index__nav'>
-        <Nav />
+          <Nav />
         </section>
         <main>
           <section className='index__header h-section pv6 pv7-ns ph2 pr7-ns cover-l'>

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,8 @@ import { Component } from 'react'
 import Link from 'next/link'
 import Nav from '../components/nav'
 import Head from '../components/head'
+import Team from '../components/team'
+
 import * as Api from '../api/api'
 
 class IndexPage extends Component {
@@ -85,7 +87,7 @@ class IndexPage extends Component {
       <div className='bg-white index tf-dark-gray'>
         <Head />
         <section className='index__nav'>
-          <Nav />
+        <Nav />
         </section>
         <main>
           <section className='index__header h-section pv6 pv7-ns ph2 pr7-ns cover-l'>
@@ -292,64 +294,7 @@ class IndexPage extends Component {
               </div>
             </div>
           </section>
-          <section className='h-section mb5 mb0-ns pb5-ns'>
-            <div className='flex flex-column z-100'>
-              <div className='bg-tf-gray o-10 dn db-ns dn-m h-section w-100 absolute' />
-              <div className='ts-title tf-oswald pt5-l center'>
-              Meet the Team
-              </div>
-              <div className='flex flex-row flex-wrap justify-center w-auto mt3 center'>
-                <div className='bg-white z-1 ma4-l w-50-m w-25-l w-80'>
-                  <div className='w-100 bg-transparent pa4-l'>
-                    <div className='pa2-l tc'>
-                      <div className='center br-100 ba b--black-05 ma3 h4 w4 bg-white overflow-hidden'>
-                        <img src='/static/images/people/joel.jpg' title='Photo of Joel Wasserman' alt='Photo of Joel Wasserman' />
-                      </div>
-                      <div className='tf-oswald ts-subtext pv2 tc'>
-                      Joel Wasserman
-                      </div>
-                      <div className='tf-lato-lite ts-subtext pt2 tc'>
-                      A software engineer at Google, Joel formerly worked
-                      at two education startups and is passionate about public education and technology.
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div className='bg-white z-1 ma4-l w-50-m w-25-l w-80'>
-                  <div className='w-100 bg-transparent pa4-l'>
-                    <div className='pa2-l tc'>
-                      <div className='center br-100 ba b--black-05 ma3 h4 w4 bg-white overflow-hidden'>
-                        <img src='/static/images/people/christine.jpeg' title='Christine Woeller Headshot' alt='Christine Woeller Headshot' />
-                      </div>
-                      <div className='tf-oswald ts-subtext pv2 tc'>
-                      Christine Woeller
-                      </div>
-                      <div className='tf-lato-lite ts-subtext pt2 tc'>
-                      With a degree in secondary education, Christine seeks to improve public schools
-                      and ensure teachers have the best resources available.
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div className='bg-white z-1 ma4-l w-50-m w-25-l w-80'>
-                  <div className='w-100 bg-transparent pa4-l'>
-                    <div className='pa2-l tc'>
-                      <div className='center br-100 ba b--black-05 ma3 h4 w4 bg-white overflow-hidden'>
-                        <img src='/static/images/people/pete.jpeg' title='Photo of Peter Squicciarini' alt='Photo of Peter Squicciarini' />
-                      </div>
-                      <div className='tf-oswald ts-subtext pv2 tc'>
-                      Peter Squicciarini
-                      </div>
-                      <div className='tf-lato-lite ts-subtext pt2 tc'>
-                      A software developer at Amazon and loving father of two, Peter strives to
-                      help all children and teachers succeed in an educational environment.
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
+          <Team />
           <section className='h-footer bg-tf-dark-gray'>
             <div className='flex flex-column m-auto w-33-l w-50-m w-100 tc'>
               <div className='white pt5 mb4 tf-oswald ts-subtext'>


### PR DESCRIPTION
Since each team member markup is the same, there was a lot of repetitive markup. I broke the team section down into components for the section and members to make things easier to read and maintain.

Within the markup, the changes I made:

- no `alt`description is needed on team photos (the attribute should always be present, but it can be an empty string) since the surrounding content (team member's name) provides context. This is a good [article](https://webaim.org/techniques/alttext/#context) on how to write good `alt` descriptions and when it can/should be empty.

- the list of teammates is really, well, a list! So I changed it to an unordered list instead of non-semantic divs

- instead of being wrapped in `divs`, team member names should be wrapped in appropriate level headings (in this case, level 3, since each section should be level 2 and the main heading should be level 1)

- every section should use heading elements for the headings instead of `divs` (I did this for the Team component and will also update the rest of the headings soon)