### PR TITLE
Make donation frequency options more accessible

### DIFF
--- a/components/donateform.js
+++ b/components/donateform.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { CardElement, injectStripe } from 'react-stripe-elements'
-import TwoItemSwitcher from './twoItemSwitcher'
+import DonationFrequency from './donationFrequency'
 import Router from 'next/router'
 import * as Api from '../api/api'
 import '../static/styles/main.scss'
@@ -30,8 +30,8 @@ class DonateForm extends Component {
     this.setLocalState({ firstName: e.target.value })
   }
 
-  updateFrequency = (newVal) => {
-    this.setLocalState({ frequency: newVal })
+  updateFrequency = (ev) => {
+    this.setLocalState({ frequency: ev.target.value })
   }
 
   updateLastName = (e) => {
@@ -54,7 +54,6 @@ class DonateForm extends Component {
       const res = await this.props.stripe.createToken()
       token = res.token
     } catch (e) {
-      console.log(e)
       this.setState({ error: e.message, loading: false })
       return
     }
@@ -75,7 +74,6 @@ class DonateForm extends Component {
       })
       const response = await responseStream.json()
       if (response.ok) {
-        console.log('Donation Complete!')
         this.setState({ redirectSuccess: true, loading: false })
       } else {
         this.setState({ error: `Donation failed: ${response.message}`, loading: false })
@@ -99,18 +97,11 @@ class DonateForm extends Component {
         <div className='error tf-lato tc'>
           <p className='red'>{this.state.error}</p>
         </div>
-        <TwoItemSwitcher
-          color='black'
-          switchOneText='Give Once'
-          selectedToggle={this.state.frequency === 'once' ? 1 : 2}
-          switchTwoText='Monthly'
-          switchOneClicked={() => this.updateFrequency('once')}
-          switchTwoClicked={() => this.updateFrequency('monthly')}
-        />
-        <input className='bn ba pa2 ma1' placeholder='First name' value={this.state.firstName} onChange={this.updateFirstName} aria-label='First Name' />
-        <input className='bn ba pa2 ma1' placeholder='Last name' value={this.state.lastName} onChange={this.updateLastName} aria-label='Last Name' />
-        <input className='bn ba pa2 ma1' placeholder='Email' value={this.state.email} onChange={this.updateEmail} aria-label='Email' />
-        <input className='bn ba pa2 ma1' placeholder='$ Amount' value={this.state.amount} onChange={this.updateAmount} aria-label='Amount' />
+        <DonationFrequency updateFrequency={this.updateFrequency} frequency={this.state.frequency} />
+        <input className='bn ba pa2 ma1' placeholder='First name' value={this.state.firstName} onChange={this.updateFirstName} aria-label='First Name' aria-required='true' />
+        <input className='bn ba pa2 ma1' placeholder='Last name' value={this.state.lastName} onChange={this.updateLastName} aria-label='Last Name' aria-required='true' />
+        <input className='bn ba pa2 ma1' placeholder='Email' value={this.state.email} onChange={this.updateEmail} aria-label='Email' aria-required='true' />
+        <input className='bn ba pa2 ma1' placeholder='$ Amount' value={this.state.amount} onChange={this.updateAmount} aria-label='Amount' aria-required='true' />
         <div className='bg-white bn ba pa2 ma1'>
           <CardElement />
         </div>

--- a/components/donationFrequency.js
+++ b/components/donationFrequency.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
-const DonationFrequency = ( { updateFrequency, frequency }) => (
-  <div className='flex flex-row tf-lato justify-between ma1' role="radiogroup" aria-labelledby="donate-freq">
+const DonationFrequency = ({ updateFrequency, frequency }) => (
+  <div className='flex flex-row tf-lato justify-between ma1' role='radiogroup' aria-labelledby='donate-freq'>
     <span id='donate-freq' className='visually-hidden'>Donation Frequency</span>
     <label className={`w-100 h2 tc mt1 bn ba b--black ttu pointer flex flex-column justify-center ${frequency === 'once' ? 'bg-tf-yellow white' : 'tf-dark-gray bg-white pointer'}`}>
       <input className='visually-hidden' type='radio' name='frequency' value='once' onInput={updateFrequency} />
@@ -15,4 +15,3 @@ const DonationFrequency = ( { updateFrequency, frequency }) => (
 )
 
 export default DonationFrequency
-

--- a/components/donationFrequency.js
+++ b/components/donationFrequency.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+const DonationFrequency = ( { updateFrequency, frequency }) => (
+  <div className='flex flex-row tf-lato justify-between ma1' role="radiogroup" aria-labelledby="donate-freq">
+    <span id='donate-freq' className='visually-hidden'>Donation Frequency</span>
+    <label className={`w-100 h2 tc mt1 bn ba b--black ttu pointer flex flex-column justify-center ${frequency === 'once' ? 'bg-tf-yellow white' : 'tf-dark-gray bg-white pointer'}`}>
+      <input className='visually-hidden' type='radio' name='frequency' value='once' onInput={updateFrequency} />
+      Give Once
+    </label>
+    <label className={`w-100 h2 tc mt1 bn ba b--black ttu pointer flex flex-column justify-center ${frequency === 'monthly' ? 'bg-tf-yellow white' : 'tf-dark-gray bg-white pointer'}`}>
+      <input className='visually-hidden' type='radio' name='frequency' value='monthly' onInput={updateFrequency} />
+      Monthly
+    </label>
+  </div>
+)
+
+export default DonationFrequency
+

--- a/static/styles/main.scss
+++ b/static/styles/main.scss
@@ -10,4 +10,5 @@
 @import './partials/_fonts.scss';
 @import './partials/_spacing.scss';
 @import './partials/_display.scss';
+@import './partials/_utility.scss';
 @import './partials/_indexpage.scss';

--- a/static/styles/partials/_utility.scss
+++ b/static/styles/partials/_utility.scss
@@ -1,0 +1,10 @@
+// visually hides elements while keeping them accessible to screenreaders
+.visually-hidden {
+  height: 1px !important;
+  width: 1px !important;
+  position: absolute !important;
+  clip-path: inset(100%) !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  overflow: hidden !important;
+  white-space: nowrap !important;
+}


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/teacherfund/TeacherFund_next/issues/106#issuecomment-538775086), the frequency buttons should really be radio inputs since it is an either/or option. Using radio inputs also makes it keyboard and screenreader accessible. I was able to style it in a way that looked like the previous version, but using semantic and accessible markup.