### PR TITLE
Improve donation frequency button accessibility

### DIFF
--- a/components/donationFrequency.js
+++ b/components/donationFrequency.js
@@ -2,13 +2,13 @@ import React from 'react'
 
 const DonationFrequency = ({ updateFrequency, frequency }) => (
   <div className='flex flex-row tf-lato justify-between ma1' role='radiogroup' aria-labelledby='donate-freq'>
-    <span id='donate-freq' className='visually-hidden'>Donation Frequency</span>
-    <label className={`w-100 h2 tc mt1 bn ba b--black ttu pointer flex flex-column justify-center ${frequency === 'once' ? 'bg-tf-yellow white' : 'tf-dark-gray bg-white pointer'}`}>
-      <input className='visually-hidden' type='radio' name='frequency' value='once' onInput={updateFrequency} />
+    <span id='donate-freq' className='sr-only--text'>Donation Frequency</span>
+    <label className={`w-100 h2 tc mt1 bn ba b--black ttu pointer flex flex-column justify-center ${frequency === 'once' ? 'bg-tf-yellow tf-dark-gray' : 'tf-dark-gray bg-white pointer'}`}>
+      <input className='sr-only--input' type='radio' name='frequency' value='once' onInput={updateFrequency} />
       Give Once
     </label>
-    <label className={`w-100 h2 tc mt1 bn ba b--black ttu pointer flex flex-column justify-center ${frequency === 'monthly' ? 'bg-tf-yellow white' : 'tf-dark-gray bg-white pointer'}`}>
-      <input className='visually-hidden' type='radio' name='frequency' value='monthly' onInput={updateFrequency} />
+    <label className={`w-100 h2 tc mt1 bn ba b--black ttu pointer flex flex-column justify-center ${frequency === 'monthly' ? 'bg-tf-yellow tf-dark-gray' : 'tf-dark-gray bg-white pointer'}`}>
+      <input className='sr-only--input' type='radio' name='frequency' value='monthly' onInput={updateFrequency} />
       Monthly
     </label>
   </div>

--- a/static/styles/partials/_utility.scss
+++ b/static/styles/partials/_utility.scss
@@ -1,5 +1,6 @@
 // visually hides elements while keeping them accessible to screenreaders
-.visually-hidden {
+// should only be used for text elements that need to be hidden, not interaction elements
+.sr-only--text {
   height: 1px !important;
   width: 1px !important;
   position: absolute !important;
@@ -7,4 +8,13 @@
   clip: rect(1px, 1px, 1px, 1px) !important;
   overflow: hidden !important;
   white-space: nowrap !important;
+}
+
+// used to visually hide elements like checkboxes and radiobuttons to create custom visual representations while keeping them fully accessible
+// Credit to Scott O'Hara https://scottaohara.github.io/a11y_styled_form_controls/src/checkbox/
+.sr-only--input {
+  position: relative;
+  z-index: 2;
+  margin-top: -.75em;
+  opacity: .00001;
 }


### PR DESCRIPTION
While the previous fix improved the accessibility for keyboard users and most screenreader users, I discovered today thanks to an [article by Scott O'Hara](https://scottaohara.github.io/a11y_styled_form_controls/src/checkbox/) that using a `visually-hidden` class can still cause issues for some screenreader users and those who depend on touch. I've used the method he describes to make the `radio` inputs more accessible while still hiding them.

I also made a slight design change to something that was making the options inaccessible – the current option's text color. Using white on the yellow background made the contrast ratio fail on all levels:
https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=F6B333

Keeping the dark grey text that the unselected option has passes WCAG AA for our use case.
https://webaim.org/resources/contrastchecker/?fcolor=434343&bcolor=F6B333