### PR TITLE
Add alt text to logo in nav

### DIFF
--- a/components/nav.js
+++ b/components/nav.js
@@ -30,7 +30,7 @@ class Nav extends React.Component {
           <div className='b--tf-yellow flex justify-between flex-row w-100'>
             <div className='pointer tc'>
               <Link href='/'>
-                <img src='/static/images/Logo_with_text.png' className='w4' />
+                <img src='/static/images/Logo_with_text.png' className='w4' alt='The Teacher Fund – Home' />
               </Link>
             </div>
             <div className='fr dn db-l flex-column flex-auto-ns mv-auto'>


### PR DESCRIPTION
All non-decorative images should have `alt` text, especially when interactive. Now when a screenreader user navigates to the logo link, instead of hearing the file name read out, they will hear "The Teacher Fund – Home" knowing where the link will take them.

[Deque source on how to use alt text on logos](https://www.deque.com/blog/great-alt-text-introduction/)