### PR TITLE
Add key props to team members

### DIFF
--- a/components/team.js
+++ b/components/team.js
@@ -32,7 +32,7 @@ const Team = (props) =>
         </h2>
         <ul className='list flex flex-row flex-wrap justify-center w-auto mt3 mb0 pv0 ph0 center'>
           {teamMembers.map(member =>
-            <TeamMember name={member.name} src={member.src} bio={member.bio} />)
+            <TeamMember name={member.name} src={member.src} bio={member.bio} key={member.bio} />)
           }
         </ul>
       </div>


### PR DESCRIPTION
Every item rendered on a list in React should have a unique key prop and I forgot to do this when creating the `<Team />` component, so just a quick fix.