### PR TITLE
Use more descriptive  page titles

### DIFF
--- a/pages/account.js
+++ b/pages/account.js
@@ -53,7 +53,7 @@ class Account extends React.Component {
   render () {
     return (
       <div>
-        <Head title='Account' />
+        <Head title='Account – The Teacher Fund' />
         <Nav />
         <main>
           <div className='w-100 h-100 flex pa5'>

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -16,7 +16,7 @@ class Donate extends Component {
   render () {
     return (
       <div>
-        <Head title='Donate' />
+        <Head title='Donate – The Teacher Fund' />
         <Nav />
         <main>
           <div className='w-100 h-100 flex'>

--- a/pages/index.js
+++ b/pages/index.js
@@ -88,7 +88,7 @@ class IndexPage extends Component {
   render () {
     return (
       <main className='bg-white index tf-dark-gray'>
-        <Head />
+        <Head title='The Teacher Fund' />
         <section className='index__nav'>
           <Nav />
         </section>

--- a/pages/mission.js
+++ b/pages/mission.js
@@ -7,7 +7,7 @@ class Mission extends Component {
   render () {
     return (
       <div>
-        <Head title='Mission' />
+        <Head title='Our Mission – The Teacher Fund' />
         <Nav />
         <main>
           <div className='w-100 h-100 min-vh-100 flex-column flex bg-card'>

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -6,7 +6,7 @@ import '../static/styles/main.scss'
 const SignIn = (props) => (
   <div>
     <Nav />
-    <Head title='Sign In' />
+    <Head title='Sign In – The Teacher Fund' />
     <main>
       <div className='w-100 h-100 flex pa5'>
         <img className='absolute w-100 h-100 top-0 left-0 z-minus-1' src='/static/images/einstein.jpg' />

--- a/pages/success.js
+++ b/pages/success.js
@@ -12,7 +12,7 @@ class Success extends React.Component {
   render () {
     return (
       <div className='main-container'>
-        <Head title='Success' />
+        <Head title='Donation Successful – The Teacher Fund' />
         <Nav navColor='black' />
         <main>
           <div className='w-100 h-100 flex'>


### PR DESCRIPTION
Currently, the page titles are generic. For example "Donate". When a screenreader user is  going through their tabs or navigating to the page, the title is announced and gives them context for where they are. "Donate" where? "Success" of what? Following the [18F accessibility guidelines](https://accessibility.18f.gov/page-titles/), I've used more descriptive page titles that not only help screenreader users, but anyone looking at their open tabs. Now pages read out as "Donate - The Teacher Fund", "Donation Successful – The Teacher Fund" and so on.

