### PR TITLE
Fix donation frequency styling

### DIFF
--- a/components/donateform.js
+++ b/components/donateform.js
@@ -107,7 +107,7 @@ class DonateForm extends Component {
           <CardElement />
         </div>
         { loading && <h2 className='tc tf-lato'>Loading...</h2>}
-        <button type='submit' className='white bg-tf-teal tf-lato b tc pa2 ma3 mt4-m br-pill ttu w-75-m m-auto'>Donate</button>
+        <button type='submit' className='white bg-tf-teal tf-lato b tc pa2 mt3 mt3-m mh-auto br-pill ttu pointer w-75'>Donate</button>
       </form>
     )
   }

--- a/components/donationFrequency.js
+++ b/components/donationFrequency.js
@@ -1,13 +1,13 @@
 import React from 'react'
 
 const DonationFrequency = ({ updateFrequency, frequency }) => (
-  <div className='flex flex-row tf-lato justify-between ma1' role='radiogroup' aria-labelledby='donate-freq'>
+  <div className='flex flex-row tf-lato ma1' role='radiogroup' aria-labelledby='donate-freq'>
     <span id='donate-freq' className='sr-only--text'>Donation Frequency</span>
-    <label className={`w-100 h2 tc mt1 bn ba b--black ttu pointer flex flex-column justify-center ${frequency === 'once' ? 'bg-tf-yellow tf-dark-gray' : 'tf-dark-gray bg-white pointer'}`}>
+    <label className={`tc mt1 pv2 ph1 bn ba b--black ttu pointer flex-auto ${frequency === 'once' ? 'bg-tf-yellow tf-dark-gray' : 'tf-dark-gray bg-white pointer'}`}>
       <input className='sr-only--input' type='radio' name='frequency' value='once' onInput={updateFrequency} />
       Give Once
     </label>
-    <label className={`w-100 h2 tc mt1 bn ba b--black ttu pointer flex flex-column justify-center ${frequency === 'monthly' ? 'bg-tf-yellow tf-dark-gray' : 'tf-dark-gray bg-white pointer'}`}>
+    <label className={`tc mt1 pv2 ph1 bn ba b--black ttu pointer flex-auto ${frequency === 'monthly' ? 'bg-tf-yellow tf-dark-gray' : 'tf-dark-gray bg-white pointer'}`}>
       <input className='sr-only--input' type='radio' name='frequency' value='monthly' onInput={updateFrequency} />
       Monthly
     </label>

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -23,16 +23,16 @@ class Donate extends Component {
             <div className='w-100 h-100 absolute bg-tf-gray o-10 z-minus-1' />
             {process.browser && <div className='flex flex-column m-auto justify-between pa3 pa4-ns'>
               <div className='flex flex-column pa4-ns pa2 pb4 tf-lato tc mv-auto'>
-                <div className='tf-dark-gray f1 tf-oswald fl pb3'>
+                <h1 className='tf-dark-gray f1 tf-oswald fl pb3 mv0'>
                 Fund Teachers. Help Students.
-                </div>
-                <div className='tf-gray tf-lato-lite f3-m pa1 w-75-ns m-auto'>
+                </h1>
+                <p className='tf-gray tf-lato-lite f3-m pa1 w-75-ns m-auto mv0 lh-5 lh-copy'>
                 With 100 percent of your donation funding public school teachers in need, you can
                 give knowing that your entire gift will help equip classrooms and help students.
-                </div>
+                </p>
               </div>
               <StripeProvider apiKey='pk_live_FYwjfNktzq3upZRFbxA9hyc8'>
-                <div className='flex flex-column w5-l w-100 w-50-m m-auto'>
+                <div className='flex flex-column w5-l w-100 w-60-m m-auto'>
                   <Elements>
                     <DonateForm />
                   </Elements>

--- a/static/styles/partials/_utility.scss
+++ b/static/styles/partials/_utility.scss
@@ -16,5 +16,6 @@
   position: relative;
   z-index: 2;
   margin-top: -.75em;
+  margin-left: -1.5ch;
   opacity: .00001;
 }


### PR DESCRIPTION
Currently if you increase the font size (many users do, or zoom in), it's easy for the styling of the options to break, not only due to the fixed height and width, but the very restricted width of the form wrapper. On smaller screens, "give once" was breaking on to two lines, causing the text to break out of its container.

By removing the fixed width and height and giving the form wrapper a bit more width to breathe, the options remain intact across screen sizes. 

Before:
![donation frequency option before the change with text breaking out of its container.](https://user-images.githubusercontent.com/16426195/66541578-55ddd800-eaf5-11e9-9b08-66157da19d93.jpg)

Now:
![Donation frequency options after removing fixed sizing and increasing container width, the text no longer breaks out.](https://user-images.githubusercontent.com/16426195/66541667-b0773400-eaf5-11e9-8783-dc5d4ace31b7.jpg)
