### PR TITLE
Styling of Menu (Desktop and Mobile)

### DIFF
--- a/components/icons/hamburger.js
+++ b/components/icons/hamburger.js
@@ -1,6 +1,6 @@
 const Hamburger = () => (
   <div>
-    <svg className='hamburgerIcon' xmlns='http://www.w3.org/2000/svg' xlink='http://www.w3.org/1999/xlink' viewBox='0 0 24 24' version='1.1' x='0px' y='0px'>
+    <svg className='hamburgerIcon' id='hamburger-icon' xmlns='http://www.w3.org/2000/svg' xlink='http://www.w3.org/1999/xlink' viewBox='0 0 24 24' version='1.1' x='0px' y='0px'>
       <title>Icon/Stroke/Hamburger</title>
       <desc>Hamburger Icon.</desc>
       <g stroke='none' strokeWidth='1' fill='none' fillRule='evenodd'>

--- a/components/nav.js
+++ b/components/nav.js
@@ -49,7 +49,7 @@ class Nav extends React.Component {
                 </div>
               ))}
             </div>
-            <div className='fr dn db-l tf-yellow mv-auto'>
+            <div className='fr dn db-l tf-yellow mv-auto ml4'>
               {this.buttons.map(({ key, href, label }) => (
                 <div key={key} className='db center w-auto fr ph2'>
                   <Link href={href} key={key}>

--- a/components/nav.js
+++ b/components/nav.js
@@ -44,7 +44,7 @@ class Nav extends React.Component {
               {this.links.map(({ key, href, label }) => (
                 <div key={key} className='db center w-auto fr ph2'>
                   <Link href={href}>
-                    <a className='tf-dark-gray no-underline black pa3'>{label}</a>
+                    <a className='nav-item tf-dark-gray no-underline black pa3'>{label}</a>
                   </Link>
                 </div>
               ))}

--- a/components/nav.js
+++ b/components/nav.js
@@ -70,7 +70,6 @@ class Nav extends React.Component {
             <X />
           </div>
           <div className='flex-column flex justify-around h5 mt6 pt4 f3'>
-            <p><a href='/' className='white no-underline mv2'>Home</a></p>
             <p><a href='/donate' className='white no-underline mv2'>Donate</a></p>
             <p><a href='/mission' className='white no-underline mv2'>Our Mission</a></p>
           </div>

--- a/components/nav.js
+++ b/components/nav.js
@@ -35,7 +35,7 @@ class Nav extends React.Component {
   render () {
     return (
       <nav>
-        <div className='f6 f5-m tf-lato bg-white pv4 flex fl w-100 pl5-ns pr5-ns pl3 pr3 z-1'>
+        <div className='f6 f5-m tf-lato bg-white pv4 flex fl w-100 pl5-ns pr5-ns pl4 pr3 z-1'>
           <div className='w-70-l mh-auto b--tf-yellow flex justify-between flex-row w-100'>
             <div className='pointer tc'>
               <Link href='/'>
@@ -68,12 +68,12 @@ class Nav extends React.Component {
           </div>
         </div>
         {this.state.drawerOpen && <div className='w-100 h-100 bg-tf-dark-gray o-90 absolute white tf-lato tc pv4 pl5-ns pr5-ns'>
-          <div className='fr pt2 pr2 mr1 mt1' onClick={this.toggleDrawerOpen}>
+          <div className='fr pa2 pr3 mr1 pt2-m pr2-m mr1-m mt1-m' onClick={this.toggleDrawerOpen}>
             <X />
           </div>
           <div className='flex-column flex justify-around h5 mt6 pt4 f3'>
-            <p><a href='/donate' className='white no-underline mv2'>Donate</a></p>
-            <p><a href='/mission' className='white no-underline mv2'>Our Mission</a></p>
+            <a href='/mission' className='white no-underline mv4 w5 center'>Our Mission</a>
+            <a href='/donate' className='btn-menu no-underline pv3 br3 mv4 w4 w5-m center'>Donate</a>
           </div>
         </div>}
 

--- a/components/nav.js
+++ b/components/nav.js
@@ -23,8 +23,10 @@ class Nav extends React.Component {
     const { drawerOpen } = this.state
     if (!drawerOpen) {
       document.body.classList.add('no-scroll')
+      document.getElementById('hamburger-icon').classList.add('dn')
     } else {
       document.body.classList.remove('no-scroll')
+      document.getElementById('hamburger-icon').classList.remove('dn')
     }
 
     this.setState({ drawerOpen: !drawerOpen })
@@ -65,8 +67,8 @@ class Nav extends React.Component {
             </div>
           </div>
         </div>
-        {this.state.drawerOpen && <div className='w-100 h-100 bg-tf-dark-gray o-90 absolute white tf-lato tc'>
-          <div className='fr ma3 ma4-m' onClick={this.toggleDrawerOpen}>
+        {this.state.drawerOpen && <div className='w-100 h-100 bg-tf-dark-gray o-90 absolute white tf-lato tc pv4 pl5-ns pr5-ns'>
+          <div className='fr pt2 pr2 mr1 mt1' onClick={this.toggleDrawerOpen}>
             <X />
           </div>
           <div className='flex-column flex justify-around h5 mt6 pt4 f3'>

--- a/static/styles/_mixins.scss
+++ b/static/styles/_mixins.scss
@@ -14,7 +14,7 @@
   color: $color;
   background-color: $background;
   box-shadow: inset 0 0 0 0.2rem $color;
-  transition: all 0.4s cubic-bezier(0.45, 0.05, 0.55, 0.95);;
+  transition: all 0.4s cubic-bezier(0.45, 0.05, 0.55, 0.95);
 
   &:hover {
     cursor: pointer;
@@ -22,6 +22,11 @@
     color: $background;
     box-shadow: $shadow-light;
   }
+}
+@mixin btn-menu($background, $color) {
+  color: $color;
+  background-color: $background;
+  box-shadow: inset 0 0 0 0.2rem $color;
 }
 @mixin btn-darken($background, $color) {
   background-color: $background;

--- a/static/styles/_mixins.scss
+++ b/static/styles/_mixins.scss
@@ -1,7 +1,7 @@
 @mixin btn-default($background, $color) {
   background-color: $background;
   color: $color;
-  
+
   &:hover {
     cursor: pointer;
     color: $background;
@@ -14,7 +14,8 @@
   color: $color;
   background-color: $background;
   box-shadow: inset 0 0 0 0.2rem $color;
-  
+  transition: all 0.4s cubic-bezier(0.45, 0.05, 0.55, 0.95);;
+
   &:hover {
     cursor: pointer;
     background-color: $color;

--- a/static/styles/partials/_colors.scss
+++ b/static/styles/partials/_colors.scss
@@ -75,3 +75,7 @@
 .bg-trans-gray {
   background-color: rgba($light-gray, 0.1);
 }
+
+.nav-item:hover{
+  color: lighten($lead-gray, 25%);
+}

--- a/static/styles/partials/_components.scss
+++ b/static/styles/partials/_components.scss
@@ -7,6 +7,9 @@
 .btn-alt {
   @include btn-alt(white, $pencil-yellow);
 }
+.btn-menu{
+  @include btn-menu(inherit, $pencil-yellow);
+}
 .btn-donate {
   @include btn-darken($dark-teal, white);
 }


### PR DESCRIPTION
This PR addresses issue #161 

The PR is missing the logo resize steps. If I make the logo 50% larger the header is too big, these are 3 possible solutions:

1. Same edge:
![teach-header-sameedge](https://user-images.githubusercontent.com/40834560/68642659-7dcfb980-0541-11ea-8f24-78ab4f76b0df.png)
2. Edge 50%:
![teach-header-edge50](https://user-images.githubusercontent.com/40834560/68642658-7d372300-0541-11ea-870f-ae6c172f81d1.png)
3. Edge 25%:
![teach-header-edge25](https://user-images.githubusercontent.com/40834560/68642657-7d372300-0541-11ea-9795-2d2708c512e8.png)

I'll add these steps to the PR as soon as I get feedback

