### PR TITLE
fixed OG meta tags.

### DIFF
--- a/components/head.js
+++ b/components/head.js
@@ -4,7 +4,7 @@ import { string } from 'prop-types'
 import '../static/styles/main.scss'
 
 const defaultDescription = "Funding Teachers. Empowering Students. We provide funding to classrooms so teachers don't have to."
-const defaultOGURL = ''
+const defaultOGURL = 'https://theteacherfund.com'
 const defaultOGImage = 'https://theteacherfund.com/static/images/Logo.png'
 
 const Head = props => (

--- a/components/head.js
+++ b/components/head.js
@@ -5,7 +5,7 @@ import '../static/styles/main.scss'
 
 const defaultDescription = "Funding Teachers. Empowering Students. We provide funding to classrooms so teachers don't have to."
 const defaultOGURL = ''
-const defaultOGImage = ''
+const defaultOGImage = 'https://theteacherfund.com/static/images/Logo.png'
 
 const Head = props => (
   <div>
@@ -22,6 +22,7 @@ const Head = props => (
       <link rel='apple-touch-icon' href='/static/touch-icon.png' />
       <link rel='mask-icon' href='/static/favicon-mask.svg' color='#49B882' />
       <link rel='icon' href='/static/favicon.ico' />
+      <meta property='og:type' content='website' />
       <meta property='og:url' content={props.url || defaultOGURL} />
       <meta property='og:title' content={props.title || ''} />
       <meta


### PR DESCRIPTION
PR for Issue #170. 

1. Added working link to `defaultOGImage` within head.js.
2. Added og:type tag to head.js.

Some issues I felt like mentioning from Facebook's sharing debugger:

Invalid OG URL
The given value '' for property 'og:url' was not a valid absolute URL.
Missing Properties
The following required properties are missing: fb:app_id

^ If needed, I could definitely add these too!