### PR TITLE
Dev/fixed the donate again bug for recurring donations

### DIFF
--- a/components/donateform.js
+++ b/components/donateform.js
@@ -109,7 +109,7 @@ export default function DonateForm ({ initialFrequency = 0 }) {
       setLocalState({ isCheckoutSessionReady: true, loading: false })
       setCheckoutSession(responseData)
     } catch (error) {
-      setLocalState({ error: 'Failed to create checkout session', loading: false })
+      setLocalState({ error: error.message || 'Failed to create checkout session', loading: false })
     }
   }
 

--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -11,7 +11,6 @@ function fetcher (route) {
 export function useAuth () {
   const { data: user, error, isValidating, mutate: revalidate } = useSWR('/api/account', fetcher)
   const loading = (user === undefined || isValidating)
-
   return { user, loading, revalidate, error }
 }
 

--- a/pages/api/stripe/checkout-session.js
+++ b/pages/api/stripe/checkout-session.js
@@ -27,17 +27,25 @@ export default async (req, res) => {
   // Create checkout session for the user
   try {
     // Cancel the customer's existing subscription
-    const { data: subscriptions } = await stripe.subscriptions.list({
-      customer: customer.id,
-      status: 'active',
-      limit: 1
-    })
-
-    if (subscriptions.length > 0) {
-      await stripe.subscriptions.cancel(subscriptions[0].id, {
-        invoice_now: true,
-        prorate: false
+    if (!isTicketPurchase && recurring) {
+      const { data: subscriptions } = await stripe.subscriptions.list({
+        customer: customer.id,
+        status: 'active',
+        limit: 1
       })
+
+      if (subscriptions.length > 0) {
+        // Ensure it is not the same subscription
+        const { items: { data: [firstItem] } } = subscriptions[0]
+        if (firstItem.price.unit_amount === data.amount) {
+          return res.status(400).json({ error: 'You already have a recurring donation of the same amount' })
+        }
+
+        await stripe.subscriptions.cancel(subscriptions[0].id, {
+          invoice_now: true,
+          prorate: false
+        })
+      }
     }
 
     // Create a new checkout session

--- a/pages/api/stripe/checkout-session.js
+++ b/pages/api/stripe/checkout-session.js
@@ -41,10 +41,7 @@ export default async (req, res) => {
           return res.status(400).json({ error: 'You already have a recurring donation of the same amount' })
         }
 
-        await stripe.subscriptions.cancel(subscriptions[0].id, {
-          invoice_now: true,
-          prorate: false
-        })
+        await stripe.subscriptions.cancel(subscriptions[0].id)
       }
     }
 

--- a/pages/api/stripe/checkout-session.js
+++ b/pages/api/stripe/checkout-session.js
@@ -26,6 +26,21 @@ export default async (req, res) => {
 
   // Create checkout session for the user
   try {
+    // Cancel the customer's existing subscription
+    const { data: subscriptions } = await stripe.subscriptions.list({
+      customer: customer.id,
+      status: 'active',
+      limit: 1
+    })
+
+    if (subscriptions.length > 0) {
+      await stripe.subscriptions.cancel(subscriptions[0].id, {
+        invoice_now: true,
+        prorate: false
+      })
+    }
+
+    // Create a new checkout session
     const session = await stripe.checkout.sessions.create({
       customer: customer.id,
       ui_mode: 'custom',


### PR DESCRIPTION
# Donate Again Button Issue Fixed

Before this PR, the `Donate Again` button had a flaw: It allows for multiple recurring donations. For a one-time donation, this would have been a good idea, but not for the recurring donations.

> A typical funder's thought process when clicking the button would be to either increase or decrease the amount they donate monthly.

This thought process has been taking into account in this PR. Donate again now cancels any existing recurring donation and start a new one, as long as it is not a duplicate, i.e., same amount as the existing active recurring donation.