### PR TITLE
hotfix: fixed the error that shows up in the console for donation confirmation

### DIFF
--- a/components/existingDonationDialog.js
+++ b/components/existingDonationDialog.js
@@ -51,7 +51,7 @@ const ExistingDonationDialog = ({
             we'll update it for you to <strong>${newAmount}</strong> from now on.
           </Text>
         </DialogBody>
-        <DialogFooter className='flex justify-center gap-4'>
+        <DialogFooter className='flex justify-end gap-4'>
           <DialogActionTrigger asChild>
             <Button
               onClick={onCancel}
@@ -99,10 +99,9 @@ const ExistingDonationDialog = ({
         </DialogFooter>
         <DialogCloseTrigger asChild>
           <CloseButton
+            as='span'
             size='sm'
             position='absolute'
-            top='1rem'
-            right='1rem'
             color='#95a4a6'
             _hover={{
               color: '#434343',

--- a/components/existingDonationDialog.js
+++ b/components/existingDonationDialog.js
@@ -51,7 +51,7 @@ const ExistingDonationDialog = ({
             we'll update it for you to <strong>${newAmount}</strong> from now on.
           </Text>
         </DialogBody>
-        <DialogFooter className='flex justify-end gap-4'>
+        <DialogFooter className='flex justify-center gap-4'>
           <DialogActionTrigger asChild>
             <Button
               onClick={onCancel}


### PR DESCRIPTION
In response to the issue #279, the commit and PR were created.

This error was thrown in the console because the close button from Chakra UI was nested inside the dialog close trigger component, which itself seems to be a button.

To fix it, I made the close button a span element inside the trigger.

While at it, I also made the action buttons justified to the end, instead of the center, because it feels aesthetically better there.