### PR TITLE
Feat/paginate customer charges

### DIFF
--- a/pages/api/stripe/donations/user.js
+++ b/pages/api/stripe/donations/user.js
@@ -33,6 +33,7 @@ export default async (req, res) => {
       customerTransactions.data.user = { firstName, lastName }
     }
 
+    // used for stripe pagination, as stripe limits to 100 items per request
     let allCharges = []
     let hasMore = true
     let startingAfter = null
@@ -59,8 +60,11 @@ export default async (req, res) => {
       allCharges = allCharges.concat(chargesData.data)
 
       hasMore = chargesData.has_more
-      if (hasMore) {
+
+      if (hasMore && chargesData.data.length > 0) {
         startingAfter = chargesData.data[chargesData.data.length - 1].id
+      } else {
+        hasMore = false
       }
     }
 

--- a/pages/api/stripe/donations/user.js
+++ b/pages/api/stripe/donations/user.js
@@ -21,11 +21,8 @@ export default async (req, res) => {
     if (!customer) {
       return res.json(customerTransactions)
     }
+
     const { id, metadata } = customer
-    const opts = {
-      customer: id,
-      limit: 100
-    }
     const { query } = req
     const { start, end } = query
     const startDate = start && getUnix(new Date(start))
@@ -36,17 +33,38 @@ export default async (req, res) => {
       customerTransactions.data.user = { firstName, lastName }
     }
 
-    if (startDate || endDate) {
-      opts.created = {}
-      if (startDate) {
-        opts.created.gte = startDate
+    let allCharges = []
+    let hasMore = true
+    let startingAfter = null
+
+    while (hasMore) {
+      const opts = {
+        customer: id,
+        limit: 100,
+        starting_after: startingAfter || undefined
       }
-      if (endDate) {
-        opts.created.lte = endDate
+
+      if (startDate || endDate) {
+        opts.created = {}
+        if (startDate) {
+          opts.created.gte = startDate
+        }
+        if (endDate) {
+          opts.created.lte = endDate
+        }
+      }
+
+      const chargesData = await stripe.charges.list(opts)
+
+      allCharges = allCharges.concat(chargesData.data)
+
+      hasMore = chargesData.has_more
+      if (hasMore) {
+        startingAfter = chargesData.data[chargesData.data.length - 1].id
       }
     }
-    const chargesData = await stripe.charges.list(opts)
-    customerTransactions.data.transactions = chargesData.data.map(charge => {
+
+    customerTransactions.data.transactions = allCharges.map((charge) => {
       const { amount, created } = charge
       return { amount, created }
     })

--- a/pages/api/stripe/donations/user.js
+++ b/pages/api/stripe/donations/user.js
@@ -22,7 +22,10 @@ export default async (req, res) => {
       return res.json(customerTransactions)
     }
     const { id, metadata } = customer
-    const opts = { customer: id }
+    const opts = {
+      customer: id,
+      limit: 100
+    }
     const { query } = req
     const { start, end } = query
     const startDate = start && getUnix(new Date(start))


### PR DESCRIPTION
 I added a while loop to the donation's api so it automatically pages through every transaction for the selected tax year before the pdf is generated. Using the "starting_after" parameter to keep track of the page until "has_more" returns false in the stripe response